### PR TITLE
Fix/post duration seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: scala
 
 scala:
-- 2.12.6
+- 2.12.8
 
 env:
   global:

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ import scalariform.formatter.preferences._
 
 name := "airlock-sts"
 
-version := "0.1"
+version := "0.0.11"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.8"
 
 scalacOptions := Seq(
   "-unchecked",
@@ -23,13 +23,13 @@ updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true
 
 assemblyJarName in assembly := "airlock-sts.jar"
 
-val akkaVersion = "10.1.3"
-val keycloakVersion = "4.2.1.Final"
+val akkaVersion = "10.1.5"
+val keycloakVersion = "4.7.0.Final"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % "2.5.14",
-  "ch.megard" %% "akka-http-cors" % "0.3.0",
+  "com.typesafe.akka" %% "akka-stream" % "2.5.19",
+  "ch.megard" %% "akka-http-cors" % "0.3.1",
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaVersion,
   "com.typesafe.akka" %% "akka-http-xml" % akkaVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
@@ -38,10 +38,11 @@ libraryDependencies ++= Seq(
   "org.keycloak" % "keycloak-adapter-core" % keycloakVersion,
   "org.jboss.logging" % "jboss-logging" % "3.3.2.Final",
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
+  "org.mariadb.jdbc" % "mariadb-java-client" % "2.3.0",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test, it",
   "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion % Test,
-  "com.amazonaws" % "aws-java-sdk-sts" % "1.11.376" % IntegrationTest,
-  "org.mariadb.jdbc" % "mariadb-java-client" % "2.3.0")
+  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.19" % Test,
+  "com.amazonaws" % "aws-java-sdk-sts" % "1.11.467" % IntegrationTest)
 
 
 configs(IntegrationTest)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.6
+sbt.version = 1.2.7

--- a/src/main/scala/com/ing/wbaa/airlock/sts/api/STSApi.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/sts/api/STSApi.scala
@@ -31,7 +31,11 @@ trait STSApi extends LazyLogging with TokenXML {
   }
   private val getSessionTokenInputs = {
     val input = "DurationSeconds".as[Int].?
-    (parameters(input) | formField(input)).tmap(t => t.copy(parseDurationSeconds(t._1)))
+    (parameter(input) & formField(input)).tmap {
+      case (param, field) =>
+        if (param.isDefined) parseDurationSeconds(param)
+        else parseDurationSeconds(field)
+    }
   }
 
   protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroup: Option[UserAssumedGroup]): Future[AwsCredentialWithToken]


### PR DESCRIPTION
for _getSessionTokenInputs_ the **DurationSeconds** param is an ```Option```
so the `parameter(input)` in
```scala
    (parameter(input) | formField(input)).tmap(t => t.copy(parseDurationSeconds(t._1)))
``` 
was never `Rejection`  (was None or Some) and the `formField(input)` never happand.